### PR TITLE
Update README linux install

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,6 +15,7 @@ Install the Snappy C library. On Linux:
 
 .. code-block:: bash
 
+   sudo apt-get update
    sudo apt-get install libsnappy-dev
 
 On OSX using Homebrew:


### PR DESCRIPTION
Directly typing 
`sudo apt-get install libsnappy-dev`
on Ubuntu gives an 
`unable to locate package` error on Ubuntu

Updating first solves this.