### PR TITLE
ensure inputted values retain data-type 

### DIFF
--- a/bluesky_browser/search.py
+++ b/bluesky_browser/search.py
@@ -209,7 +209,7 @@ class SearchState(ConfigurableQObject):
                 continue
             if not header_labels_set:
                 # Set header labels just once.
-                self.search_results_model.setHorizontalHeaderLabels(list(row_text))
+                self.search_results_model.setHorizontalHeaderLabels(list(row_data))
                 header_labels_set = True
             for value in row_data.values():
                 item = QStandardItem()

--- a/bluesky_browser/search.py
+++ b/bluesky_browser/search.py
@@ -58,7 +58,7 @@ def default_search_result_row(entry):
         str_duration = str(duration)
         str_duration = str_duration[:str_duration.index('.')]
     return {'Unique ID': start['uid'][:8],
-            'Transient Scan ID': str(start.get('scan_id', '-')),
+            'Transient Scan ID': (start.get('scan_id', '-')),
             'Plan Name': start.get('plan_name', '-'),
             'Start Time': start_time.strftime('%Y-%m-%d %H:%M:%S'),
             'Duration': str_duration,
@@ -204,15 +204,16 @@ class SearchState(ConfigurableQObject):
             self._results.append(uid)
             row = []
             try:
-                row_text = self.apply_search_result_row(entry)
+                row_data = self.apply_search_result_row(entry)
             except SkipRow:
                 continue
             if not header_labels_set:
                 # Set header labels just once.
                 self.search_results_model.setHorizontalHeaderLabels(list(row_text))
                 header_labels_set = True
-            for text in row_text.values():
-                item = QStandardItem(text or '')
+            for value in row_data.values():
+                item = QStandardItem()
+                item.setData(value, Qt.DisplayRole)
                 row.append(item)
             self.search_results_model.appendRow(row)
         if counter:


### PR DESCRIPTION
In addition to using `item.setdata(value, Qt.DisplayRole)` to ensure that inputted values retain there `type` I also changed the name of `row_text` to `row_data` to better indicate that this is not a strictly text based item.

I also had to remove the casting of the scanID to a string.

This was tested using the bluesky-browser demo locally and achieved the required results.

also this fixes #23 