### PR TITLE
Add export functionality

### DIFF
--- a/bluesky_browser/suitcase.py
+++ b/bluesky_browser/suitcase.py
@@ -61,16 +61,21 @@ class SuitcaseWidget(ConfigurableQWidget):
                                   'textChanged')
 
     def show_parameters(self, parameters=[]):
-        '''Walks through ``parameters`` then ``self.parameters`` showing the
+        '''Walks through ``self.parameters`` then ``parameters`` showing the
            widgets.'''
 
         # add any parameters from self.parameters, if they are unique.
+        combined_parameters = []
         for parameter in self.parameters:
-            if parameter not in parameters:
-                parameters.append(parameter)
+            if parameter not in combined_parameters:
+                combined_parameters.append(parameter)
+        # add any parameters from the kwarg parameters, if they are unique.
+        for parameter in parameters:
+            if parameter not in combined_parameters:
+                combined_parameters.append(parameter)
 
         # step through each parameter and add the widget to the layout.
-        for parameter in parameters:
+        for parameter in combined_parameters:
             # collect the trait and widget_type objects.
             trait_widget = getattr(self, f'{parameter}_widget')
             self.main_layout.addRow(parameter, trait_widget)
@@ -250,23 +255,26 @@ class csvSuitcaseWidget(SuitcaseWidget):
                                   'textChanged')
 
     def show_parameters(self, parameters=[]):
-        '''Walks through ``parameters`` then ``super().parameters`` showing the
-        widgets.
+        '''Walks through ``super().parameters``, ``self.parameters`` then
+        ``parameters`` showing the widgets in each.
 
-        NOTE: This modified version is required for all child classes. The call
-        to ``super().parameters`` from inside ``super().show_parameters()``
-        does not find any parameters.
+        NOTE: This modified version is required for all child classes. It
+        ensures that the self.parameters from the parent class supercedes all
+        others so that multiple types of suitcaseWidgets have a consistent
+        order and visibility for common traits.
         '''
-        # add any parent parameters first if they exist.
-        try:
-            # add any parameters from super.parameters, if they are unique.
-            for parameter in super().parameters:
-                if parameter not in parameters:
-                    parameters.append(parameter)
-        except AttributeError:
-            ...
 
-        super().show_parameters(parameters=parameters)
+        # add any parameters from self.parameters, if they are unique.
+        combined_parameters = []
+        for parameter in self.parameters:
+            if parameter not in combined_parameters:
+                combined_parameters.append(parameter)
+        # add any parameters from the kwarg parameters, if they are unique.
+        for parameter in parameters:
+            if parameter not in combined_parameters:
+                combined_parameters.append(parameter)
+        # make the call to the parent method
+        super().show_parameters(parameters=combined_parameters)
 
 
 class export_widget(ConfigurableQWidget):

--- a/bluesky_browser/suitcase.py
+++ b/bluesky_browser/suitcase.py
@@ -39,7 +39,6 @@ class SuitcaseWidget(ConfigurableQWidget):
     # Tuple giving the (left, top, width, height) size of the required window
     geometry = traitlets.Tuple((10, 10, 600, 200))
 
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.initGUI()
@@ -67,7 +66,8 @@ class SuitcaseWidget(ConfigurableQWidget):
 
         # add any parameters from self.parameters, if they are unique.
         for parameter in self.parameters:
-            if parameter not in parameters: parameters.append(parameter)
+            if parameter not in parameters:
+                parameters.append(parameter)
 
         # step through each parameter and add the widget to the layout.
         for parameter in parameters:
@@ -249,7 +249,7 @@ class csvSuitcaseWidget(SuitcaseWidget):
         self._create_trait_widget('decimal', QLineEdit, 'setText',
                                   'textChanged')
 
-    def show_parameters(self, parameters = []):
+    def show_parameters(self, parameters=[]):
         '''Walks through ``parameters`` then ``super().parameters`` showing the
         widgets.
 
@@ -261,7 +261,8 @@ class csvSuitcaseWidget(SuitcaseWidget):
         try:
             # add any parameters from super.parameters, if they are unique.
             for parameter in super().parameters:
-                if parameter not in parameters: parameters.append(parameter)
+                if parameter not in parameters:
+                    parameters.append(parameter)
         except AttributeError:
             ...
 

--- a/bluesky_browser/suitcase.py
+++ b/bluesky_browser/suitcase.py
@@ -1,6 +1,6 @@
 import traitlets
 from PyQt5.QtWidgets import (QPushButton, QVBoxLayout, QTabWidget, QCheckBox,
-                             QFormLayout, QLineEdit, QSpinBox)
+                             QFormLayout, QLineEdit, QSpinBox, QMessageBox)
 import suitcase.csv
 import suitcase.json_metadata
 import suitcase.specfile
@@ -337,6 +337,9 @@ class export_widget(ConfigurableQWidget):
 
     def _export_clicked(self):
         '''The function run when the export button is clicked.'''
+
+        has_exported = False  # indicates if an export has occured.
+
         for suitcase_label in self.suitcases:  # step through each suitcase
             temp_widget = getattr(self, f'{suitcase_label}_widget')
             if temp_widget.enable_checkbox.isChecked():
@@ -344,6 +347,20 @@ class export_widget(ConfigurableQWidget):
                 kwargs = {'file_prefix': getattr(temp_widget,
                                                  'file_prefix_widget').text()}
                 export_file(suitcase_label, self.entries, directory, **kwargs)
+                has_exported = True
+
+        # In case no suitcase types are marked for export warn the user
+        if not has_exported:
+            warning = QMessageBox()
+            warning.setIcon(QMessageBox.Information)
+            warning.setWindowTitle('No Export Warning')
+            warning.setText('None of the suitcase types where exported')
+            warning.setDetailedText('This warning generally occurs because the'
+                                    ' "enable exporter" checkbox was not '
+                                    'checked for any of the suitcase types.')
+            warning.setStandardButtons(QMessageBox.Ok)
+            warning.exec_()
+
         self.close()
 
     def _cancel_clicked(self):

--- a/bluesky_browser/suitcase.py
+++ b/bluesky_browser/suitcase.py
@@ -1,14 +1,145 @@
+import suitcase.csv
 import suitcase.json_metadata
+import suitcase.specfile
+import suitcase.tiff_stack
+import suitcase.tiff_series
+from PyQt5.QtWidgets import (QPushButton, QVBoxLayout, QTabWidget, QWidget,
+                             QCheckBox, QFormLayout, QLineEdit)
 
-def export_file(entries):
-    '''exports the file with the uid given by ``uid``.
+
+class suitcase_params_widget(QWidget):
+    '''Widget for entering suitcase export parameters for a given suitcase.
+
+    Parameters
+    ----------
+    file_type : str
+        The name of the suitcase repo that this widget sets params, for e.g.
+        'csv' for ``suitcase.csv``
+    *args : args
+        args passed down to QWidget
+    **kwargs : kwargs
+        kwargs passed down to QWidget
+    default_values : dict
+        dictionary giving default values for the input parameters 'directory'
+        and 'file_prefix'.
+    '''
+
+    def __init__(self, file_type, *args, geometry=(10, 10, 400, 140),
+                 default_values={}, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.file_type = file_type
+        self.geometry = geometry
+        self.default_values = default_values
+        self.initUI()
+
+    def initUI(self):
+        self.setWindowTitle(f'Exporter for {self.file_type} files:')
+        self.setGeometry(*self.geometry)
+
+        self.main_layout = QFormLayout()
+
+        self.enable_checkbox = QCheckBox('enable exporter', self)
+        self.main_layout.addRow('', self.enable_checkbox)
+
+        self.directory = QLineEdit(self)
+        self.directory.setText(self.default_values.pop('directory', ''))
+        self.main_layout.addRow('directory', self.directory)
+
+        self.file_prefix = QLineEdit(self)
+        self.file_prefix.setText(self.default_values.pop('file_prefix', ''))
+        self.main_layout.addRow('file_prefix', self.file_prefix)
+
+        self.setLayout(self.main_layout)
+
+
+class export_widget(QWidget):
+    ''' Widget for exporting using suitcases.
+
+    Parameters:
+    suitcase_list : list
+        List of suitcase repo's that this widget sets params, for e.g.
+        'csv' for ``suitcase.csv``
+    *args : args
+        args passed down to QWidget
+    **kwargs : kwargs
+        kwargs passed down to QWidget
+    '''
+    def __init__(self, entries, suitcase_list, *args,
+                 geometry=(10, 10, 400, 140), default_values={}, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.entries = entries
+        self.suitcase_list = suitcase_list
+        self.geometry = geometry
+        self.default_values = default_values
+        self.initUI()
+
+    def initUI(self):
+        '''generate the layout of the widget.'''
+        # set Window parameters
+        self.setWindowTitle('export dialog box')
+        self.setGeometry(*self.geometry)
+        # set the widget layout
+        self.layout = QVBoxLayout()
+
+        # add each of the required suitcase tabs
+        self.suitcase_tabs = QTabWidget()
+        for suitcase_type in self.suitcase_list:
+            setattr(self, f'{suitcase_type}_widget',
+                    suitcase_params_widget(
+                        suitcase_type,
+                        default_values=self.default_values[suitcase_type]))
+            temp_widget = getattr(self, f'{suitcase_type}_widget')
+            setattr(self.suitcase_tabs, f'{suitcase_type}_tab', temp_widget)
+            temp_tab = getattr(self.suitcase_tabs, f'{suitcase_type}_tab')
+            temp_tab.layout = QVBoxLayout()
+            temp_tab.layout.addWidget(temp_widget)
+            temp_tab.setLayout(temp_tab.layout)
+            self.suitcase_tabs.addTab(temp_tab, suitcase_type)
+        # add the tabs to the layout
+        self.layout.addWidget(self.suitcase_tabs)
+        # add an export button
+        self.export_button = QPushButton('export', self)
+        self.export_button.clicked.connect(self._export_clicked)
+        self.layout.addWidget(self.export_button)
+        # add a cancel button
+        self.cancel_button = QPushButton('cancel', self)
+        self.cancel_button.clicked.connect(self._cancel_clicked)
+        self.layout.addWidget(self.cancel_button)
+
+        # set the layout
+        self.setLayout(self.layout)
+
+    def _export_clicked(self):
+        '''The function run when the export button is clicked.'''
+        for suitcase_type in self.suitcase_list:  # step through each suitcase
+            temp_widget = getattr(self, f'{suitcase_type}_widget')
+            if temp_widget.enable_checkbox.isChecked():
+                directory = temp_widget.directory.text()
+                kwargs = {'file_prefix': temp_widget.file_prefix.text()}
+                export_file(suitcase_type, self.entries, directory, **kwargs)
+        self.close()
+
+    def _cancel_clicked(self):
+        '''The function run when the cancel button is clicked.'''
+        self.close()
+
+
+def export_file(file_type, entries, directory, **kwargs):
+    '''exports the data from 'entries' to the file gieven by 'file_type'.
 
     parameters
     ----------
-    uid : str
-        The uid associated with the scan to export.
+    file_type : str
+        The name of the suitcase repo to export, e.g 'csv' for ``suitcase.csv``
+    entries : list
+        A list of ``intake-databroker`` entries associated to export.
+    directory : str
+        The name of the directory to save the files to.
+    **kwargs : dict
+        A dictionary of kwargs passed into the export function for the
+        ``file_type`` suitcase.
     '''
 
     for entry in entries:
         docs = entry.read_canonical()
-        suitcase.json_metadata.export(docs, 'test_data', 'test_data_{start[scan_id]}')
+        getattr(suitcase, file_type).export(docs, directory, **kwargs)

--- a/bluesky_browser/suitcase.py
+++ b/bluesky_browser/suitcase.py
@@ -1,0 +1,14 @@
+import suitcase.json_metadata
+
+def export_file(entries):
+    '''exports the file with the uid given by ``uid``.
+
+    parameters
+    ----------
+    uid : str
+        The uid associated with the scan to export.
+    '''
+
+    for entry in entries:
+        docs = entry.read_canonical()
+        suitcase.json_metadata.export(docs, 'test_data', 'test_data_{start[scan_id]}')

--- a/bluesky_browser/summary.py
+++ b/bluesky_browser/summary.py
@@ -8,7 +8,7 @@ from qtpy.QtWidgets import (
     QVBoxLayout,
     QWidget,
     )
-
+from .suitcase import export_file
 
 class SummaryWidget(QWidget):
     open = Signal([str, list])
@@ -29,12 +29,21 @@ class SummaryWidget(QWidget):
         self.copy_uid_button = QPushButton('Copy UID to Clipboard')
         self.copy_uid_button.hide()
         self.copy_uid_button.clicked.connect(self._copy_uid)
+        self.export_button = QPushButton('export to file')
+        self.export_button.hide()
+        self.export_button.clicked.connect(self._export)
+
         self.streams = QLabel()
         self.entries = []
 
+        uid_button_layout = QVBoxLayout()
+        uid_button_layout.addWidget(self.copy_uid_button)
+        uid_button_layout.addWidget(self.export_button)
+
         uid_layout = QHBoxLayout()
         uid_layout.addWidget(self.uid_label)
-        uid_layout.addWidget(self.copy_uid_button)
+        uid_layout.addLayout(uid_button_layout)
+
         layout = QVBoxLayout()
         layout.addWidget(self.open_individually_button)
         layout.addWidget(self.open_overplotted_button)
@@ -66,6 +75,10 @@ class SummaryWidget(QWidget):
             return
         self.open.emit(item, self.entries)
 
+    def _export(self):
+        print (f'{self.entries}')  # For testing only to see that something happens
+        export_file(self.entries)  # use the function from ``bluesky-browser.suitcase``
+
     def set_entries(self, entries):
         self.entries.clear()
         self.entries.extend(entries)
@@ -73,6 +86,7 @@ class SummaryWidget(QWidget):
             self.uid_label.setText('')
             self.streams.setText('')
             self.copy_uid_button.hide()
+            self.export_button.hide()
             self.open_individually_button.hide()
             self.open_overplotted_button.hide()
             self.open_overplotted_on_button.hide()
@@ -82,6 +96,7 @@ class SummaryWidget(QWidget):
             self.uid = run.metadata['start']['uid']
             self.uid_label.setText(self.uid[:8])
             self.copy_uid_button.show()
+            self.export_button.show()
             self.open_individually_button.show()
             self.open_individually_button.setText('Open')
             self.open_overplotted_on_button.show()
@@ -100,6 +115,7 @@ class SummaryWidget(QWidget):
             self.uid_label.setText('(Multiple Selected)')
             self.streams.setText('')
             self.copy_uid_button.hide()
+            self.export_button.hide()
             self.open_individually_button.setText('Open individually')
             self.open_individually_button.show()
             self.open_overplotted_button.show()

--- a/bluesky_browser/summary.py
+++ b/bluesky_browser/summary.py
@@ -92,9 +92,7 @@ class SummaryWidget(QWidget):
         self.open.emit(item, self.entries)
 
     def _export(self):
-        self.export_widget = export_widget(
-            self.entries, self.suitcase_list,
-            default_values=self.suitcase_default_values)
+        self.export_widget = export_widget(self.entries)
         self.export_widget.show()
 
     def set_entries(self, entries):

--- a/bluesky_browser/utils.py
+++ b/bluesky_browser/utils.py
@@ -162,6 +162,8 @@ ConfigurableQObject = MetaQObjectHasTraits(
     'NewBase', (Configurable, SuperQObject), {})
 ConfigurableQTabWidget = MetaQObjectHasTraits(
     'NewBase', (Configurable, QTabWidget, SuperQObject), {})
+ConfigurableQWidget = MetaQObjectHasTraits(
+    'NewBase', (Configurable, QWidget, SuperQObject), {})
 ConfigurableMoveableTabContainer = MetaQObjectHasTraits(
     'NewBase', (Configurable, MoveableTabContainer, SuperQObject), {})
 

--- a/bluesky_browser/utils.py
+++ b/bluesky_browser/utils.py
@@ -1,7 +1,7 @@
 import inspect
 
 from PyQt5.QtGui import QCursor, QDrag, QPixmap, QRegion
-from PyQt5.QtWidgets import QWidget, QTabWidget
+from PyQt5.QtWidgets import QWidget, QTabWidget, QLineEdit, QComboBox
 from PyQt5.QtCore import Qt, QMimeData, QObject, QPoint
 from traitlets import HasTraits, TraitType
 from traitlets.config.loader import (PyFileConfigLoader, ConfigFileNotFound,
@@ -182,3 +182,94 @@ class Callable(TraitType):
             return value
         else:
             self.error(obj, value)
+
+
+class QTextListEdit(QLineEdit):
+    '''A ``QLineEdit`` that returns a ``list`` from the ``self.text_changed``.
+
+    This adds a custom ``self.textChanged()`` method that splits the text
+    into a list of strings using ``text.split(',')``.
+    '''
+
+    def textChanged(self, *args, **kwargs):
+        text = super().textChanged(*args, **kwargs)
+        return text.split(',')
+
+
+class QIntListEdit(QLineEdit):
+    '''A ``QLineEdit`` that returns a ``list`` from the ``self.text_changed``.
+
+    This adds a custom ``self.textChanged()`` method that splits the text
+    into a list of integers using ``text.split(',')``.
+    '''
+
+    def textChanged(self, *args, **kwargs):
+        text = super().textChanged(*args, **kwargs)
+        list = text.split(',')
+        list = [int(item) for item in list]
+        return list
+
+
+class QFloatListEdit(QLineEdit):
+    '''A ``QLineEdit`` that returns a ``list`` from the ``self.text_changed``.
+
+    This adds a custom ``self.textChanged()`` method that splits the text
+    into a list of floats using ``text.split(',')``.
+    '''
+
+    def textChanged(self, *args, **kwargs):
+        text = super().textChanged(*args, **kwargs)
+        list = text.split(',')
+        list = [float(item) for item in list]
+        return list
+
+
+class QBoolBox(QComboBox):
+    '''A ``QComboBox`` that returns ``True`` or ``False``.
+
+    This adds a custom ``self.currentTextChanged`` method that converts the
+    selected string to a boolean. It also adds the items for each to the
+    options list.
+    '''
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.addItem('True')
+        self.addItem('False')
+
+    def currentTextChanged(self, *args, **kwargs):
+        str = super().currentTextChanged(*args, **kwargs)
+        if str == 'True':
+            val = True
+        elif str == 'False':
+            val = False
+        else:
+            val = str
+        return val
+
+
+class QBoolNoneBox(QComboBox):
+    '''A ``QComboBox`` that returns ``True``, ``False`` or ``None``.
+
+    This adds a custom ``self.currentTextChanged`` method that converts the
+    selected string to a boolean or None. It also adds the items for each to
+    the options list.
+    '''
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.addItem('True')
+        self.addItem('False')
+        self.addItem('None')
+
+    def currentTextChanged(self, *args, **kwargs):
+        str = super().currentTextChanged(*args, **kwargs)
+        if str == 'True':
+            val = True
+        elif str == 'False':
+            val = False
+        elif str == 'None':
+            val = None
+        else:
+            val = str
+        return val

--- a/bluesky_browser/utils.py
+++ b/bluesky_browser/utils.py
@@ -2,7 +2,7 @@ import inspect
 
 from PyQt5.QtGui import QCursor, QDrag, QPixmap, QRegion
 from PyQt5.QtWidgets import QWidget, QTabWidget, QLineEdit, QComboBox
-from PyQt5.QtCore import Qt, QMimeData, QObject, QPoint
+from PyQt5.QtCore import Qt, QMimeData, QObject, QPoint, pyqtSlot, pyqtSignal
 from traitlets import HasTraits, TraitType
 from traitlets.config.loader import (PyFileConfigLoader, ConfigFileNotFound,
                                      Config)
@@ -184,52 +184,62 @@ class Callable(TraitType):
             self.error(obj, value)
 
 
-class QTextListEdit(QLineEdit):
-    '''A ``QLineEdit`` that returns a ``list`` from the ``self.text_changed``.
+class QStrListEdit(QLineEdit):
+    '''A ``QLineEdit`` that returns a ``list`` from the ``self.listChanged``.
 
-    This adds a custom ``self.textChanged()`` method that splits the text
-    into a list of strings using ``text.split(',')``.
+    This adds a ``self.listChanged()`` ``pyqt5Signal`` and a ``self.setList``
+    ``pyqt5Slot``. This allows for lists of strings to be handled as input
+    parameters.
     '''
 
-    def textChanged(self, *args, **kwargs):
-        text = super().textChanged(*args, **kwargs)
-        return text.split(',')
+    listChanged = pyqtSignal(list)
+
+    @pyqtSlot()
+    def setList(self, value):
+        super().setText(self._list2str(value))
+        self.listChanged.emit(value)
+
+    @pyqtSlot()
+    def setText(self, str_val):
+        self.setList(self._str2list(str_val))
+
+    def _str2list(self, str_val):
+        return str_val.split(',')
+
+    def _list2str(self, val):
+        return str(val)[1:-1].replace("'", "")
 
 
-class QIntListEdit(QLineEdit):
-    '''A ``QLineEdit`` that returns a ``list`` from the ``self.text_changed``.
+class QIntListEdit(QStrListEdit):
+    '''A ``QLineEdit`` that returns a ``list`` from the ``self.listChanged``.
 
-    This adds a custom ``self.textChanged()`` method that splits the text
-    into a list of integers using ``text.split(',')``.
+    This adds a ``self.listChanged()`` ``pyqt5Signal`` and a ``self.setList``
+    ``pyqt5Slot``. This allows for lists of integers to be handled as input
+    parameters.
     '''
 
-    def textChanged(self, *args, **kwargs):
-        text = super().textChanged(*args, **kwargs)
-        list = text.split(',')
-        list = [int(item) for item in list]
-        return list
+    def _str2list(self, str_val):
+        return [int(val) for val in str_val.split(',')]
 
 
-class QFloatListEdit(QLineEdit):
-    '''A ``QLineEdit`` that returns a ``list`` from the ``self.text_changed``.
+class QFloatListEdit(QStrListEdit):
+    '''A ``QLineEdit`` that returns a ``list`` from the ``self.listChanged``.
 
-    This adds a custom ``self.textChanged()`` method that splits the text
-    into a list of floats using ``text.split(',')``.
+    This adds a ``self.listChanged()`` ``pyqt5Signal`` and a ``self.setList``
+    ``pyqt5Slot``. This allows for lists of floatss to be handled as input
+    parameters.
     '''
 
-    def textChanged(self, *args, **kwargs):
-        text = super().textChanged(*args, **kwargs)
-        list = text.split(',')
-        list = [float(item) for item in list]
-        return list
+    def _str2list(self, str_val):
+        return [float(val) for val in str_val.split(',')]
 
 
 class QBoolBox(QComboBox):
     '''A ``QComboBox`` that returns ``True`` or ``False``.
 
-    This adds a custom ``self.currentTextChanged`` method that converts the
-    selected string to a boolean. It also adds the items for each to the
-    options list.
+    This adds a custom ``self.boolChanged`` ``pyqt5Signal`` that indicates if a
+    the boolean has been updated using a new ``self.setBool`` ``pyqt5Slot``. It
+    also adds the items for each to the options list.
     '''
 
     def __init__(self, *args, **kwargs):
@@ -237,39 +247,59 @@ class QBoolBox(QComboBox):
         self.addItem('True')
         self.addItem('False')
 
-    def currentTextChanged(self, *args, **kwargs):
-        str = super().currentTextChanged(*args, **kwargs)
-        if str == 'True':
-            val = True
-        elif str == 'False':
-            val = False
-        else:
-            val = str
-        return val
+    boolChanged = pyqtSignal(bool)
+
+    @pyqtSlot()
+    def setBool(self, value):
+        super().setCurrentText(self._bool2str(value))
+        self.boolChanged.emit(value)
+
+    @pyqtSlot()
+    def setCurrentText(self, str_val):
+        self.setBool(self._str2bool(str_val))
+
+    def _bool2str(self, value):
+        if value is True:
+            str_val = 'True'
+        elif value is False:
+            str_val = 'False'
+        return str_val
+
+    def _str2bool(self, str_val):
+        if str_val == 'True':
+            value = True
+        elif str_val == 'False':
+            value = False
+        return value
 
 
-class QBoolNoneBox(QComboBox):
+class QBoolNoneBox(QBoolBox):
     '''A ``QComboBox`` that returns ``True``, ``False`` or ``None``.
 
-    This adds a custom ``self.currentTextChanged`` method that converts the
-    selected string to a boolean or None. It also adds the items for each to
-    the options list.
+    This adds a custom ``self.boolChanged`` ``pyqt5Signal`` that indicates if a
+    the boolean has been updated using a new ``self.setBool`` ``pyqt5Slot``. It
+    also adds the items for each to the options list.
     '''
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.addItem('True')
-        self.addItem('False')
         self.addItem('None')
 
-    def currentTextChanged(self, *args, **kwargs):
-        str = super().currentTextChanged(*args, **kwargs)
-        if str == 'True':
-            val = True
-        elif str == 'False':
-            val = False
-        elif str == 'None':
-            val = None
-        else:
-            val = str
-        return val
+    def _bool2str(self, value):
+
+        if value is None:
+            str_val = 'None'
+        elif value is True:
+            str_val = 'True'
+        elif value is False:
+            str_val = 'False'
+        return str_val
+
+    def _str2bool(self, str_val):
+        if str_val == 'True':
+            value = True
+        elif str_val == 'False':
+            value = False
+        elif str_val == 'None':
+            value = None
+        return value


### PR DESCRIPTION
This is meant to add export functionality to bluesky-browser as outlined in issue #34 

from issue #34 the expected process at the end is:
```
1. User selects search results and clicks Export. This opens up a dialog box.
2. Dialog box contains tabs (maybe tabs along the side?), one tab per format.
3. Each format can be activated on/off and configured (directory, file_prefix, custom options).
4. Click Go.
```

Still a work in progress, comments on what we have so far is appreciated.

So far I have added the new 'export' button, it is visible after selecting a scan from the search results.

currently this automatically exports a file containing the meta-data to /test_data/test_data_'scan_id'

TODO: 
- [x] add dialog box to ask for parameter inputs with 'Go button'
- [x] add additional tabs to dialog box for other suitcase options
- [ ] add on-disk persistence of export parameters for quick saving second time around.
- [ ] add list of required suitcases to configuration file