### PR TITLE
Avoid 'getting' the entry in displaying search result.

### DIFF
--- a/bluesky_browser/search.py
+++ b/bluesky_browser/search.py
@@ -48,8 +48,9 @@ _validate = functools.partial(jsonschema.validate, types={'array': (list, tuple)
 
 
 def default_search_result_row(entry):
-    start = entry.metadata['start']
-    stop = entry.metadata['stop']
+    metadata = entry.describe()['metadata']
+    start = metadata['start']
+    stop = metadata['stop']
     start_time = datetime.fromtimestamp(start['time'])
     if stop is None:
         str_duration = '-'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 bluesky
 event-model >=1.9.0a3
+intake >=0.5.1
 intake-bluesky >=0.1.0a5
 jsonschema
 matplotlib


### PR DESCRIPTION
At SST, this reduced the time to display 100 results from 10s of seconds to < 1
second.

The speedup is due to the fact that `entry()` or equivalently `entry.get()` instantiates a `BlueskyRun` object and incurs some additional MongoDB queries, whereas `describe()` does not.