### PR TITLE
Log if configuration is not found.

### DIFF
--- a/bluesky_browser/utils.py
+++ b/bluesky_browser/utils.py
@@ -1,4 +1,5 @@
 import inspect
+import logging
 
 from PyQt5.QtGui import QCursor, QDrag, QPixmap, QRegion
 from PyQt5.QtWidgets import QWidget, QTabWidget
@@ -7,6 +8,9 @@ from traitlets import HasTraits, TraitType
 from traitlets.config.loader import (PyFileConfigLoader, ConfigFileNotFound,
                                      Config)
 from traitlets.config import Configurable
+
+
+log = logging.getLogger('bluesky_browser')
 
 
 class MoveableTabWidget(QTabWidget):
@@ -88,6 +92,7 @@ def load_config():
     try:
         config = loader.load_config()
     except ConfigFileNotFound:
+        log.info("No configuration file found.")
         config = Config()
     return config
 


### PR DESCRIPTION
I lost a minute because I didn't realize I was in the wrong directly and
the GUI was not finding its config file. This should make that more
obvious.

If a config file _is_ found, it would be nice to log _where_ but it's not
obvious how to do that using the ``PyFileConfigLoader``, so this is good enough
for now.