### PR TITLE
Address QT UI locking when polling catalogs

### DIFF
--- a/bluesky_browser/frameworks/qt/search.py
+++ b/bluesky_browser/frameworks/qt/search.py
@@ -212,6 +212,7 @@ class SearchState(ConfigurableQObject):
         counter = 0
 
         while not self._new_entries.empty():
+            counter += 1
             entry = self._new_entries.get()
             row = []
             try:

--- a/bluesky_browser/frameworks/qt/search.py
+++ b/bluesky_browser/frameworks/qt/search.py
@@ -104,12 +104,10 @@ class SearchState(ConfigurableQObject):
                     # Never reload until the last reload finished being
                     # displayed.
                     search_state.show_results_event.wait()
-                    print("reload_thread unwaited 0")
                     # Wait for RELOAD_INTERVAL to pass or until we are poked,
                     # whichever happens first.
                     search_state.reload_event.wait(
                         max(0, RELOAD_INTERVAL - (time.monotonic() - t0)))
-                    print("reload_thread unwaited 1")
                     search_state.reload_event.clear()
                     # Reload the catalog to show any new results.
                     search_state.reload()
@@ -174,6 +172,14 @@ class SearchState(ConfigurableQObject):
         self.selected_catalog = self.catalog[name]()
         self.search()
 
+    def check_for_new_entries(self):
+        # check for any new results and add them to the queue for later processing
+        for uid, entry in itertools.islice(self._results_catalog.items(), MAX_SEARCH_RESULTS):
+            if uid in self._results:
+                continue
+            self._results.append(uid)
+            self._new_entries.put(entry)
+
     def process_queries(self):
         # If there is a backlog, process only the newer query.
         block = True
@@ -188,17 +194,10 @@ class SearchState(ConfigurableQObject):
         log.debug('Submitting query %r', query)
         t0 = time.monotonic()
         self._results_catalog = self.selected_catalog.search(query)
-        #check for any new results and add them to the queue for later processing
-        for uid, entry in itertools.islice(self._results_catalog.items(), MAX_SEARCH_RESULTS):
-            if uid in self._results:
-                continue
-            print("new catalog")
-            self._results.append(uid)
-            self._new_entries.put(entry)
+        self.check_for_new_entries()
         duration = time.monotonic() - t0
         log.debug('Query yielded %r results (%.3f s).',
                   len(self._results_catalog), duration)
-        print("emit new_results_catalog)")
         self.new_results_catalog.emit()
 
     def search(self):
@@ -244,10 +243,10 @@ class SearchState(ConfigurableQObject):
         self.show_results_event.set()
 
     def reload(self):
-        print("in reload")
         t0 = time.monotonic()
         if self._results_catalog is not None:
             self._results_catalog.reload()
+            self.check_for_new_entries()
             duration = time.monotonic() - t0
             log.debug("Reloaded search results (%.3f s).", duration)
             self.new_results_catalog.emit()

--- a/bluesky_browser/frameworks/qt/search.py
+++ b/bluesky_browser/frameworks/qt/search.py
@@ -90,7 +90,7 @@ class SearchState(ConfigurableQObject):
         self.query_queue = queue.Queue()
         self.show_results_event = threading.Event()
         self.reload_event = threading.Event()
-        self.run_catalogs = {}
+
         search_state = self
 
         super().__init__()
@@ -206,7 +206,6 @@ class SearchState(ConfigurableQObject):
         self.query_queue.put(query)
 
     def show_results(self):
-        print("in show_results")
         header_labels_set = False
         self.show_results_event.clear()
         t0 = time.monotonic()
@@ -243,7 +242,6 @@ class SearchState(ConfigurableQObject):
                 self._results.append(uid)
                 self._new_entries.put(entry)
             duration = time.monotonic() - t0
-            print("Reloaded search results (%.3f s).", duration)
             log.debug("Reloaded search results (%.3f s).", duration)
             self.new_results_catalog.emit()
 


### PR DESCRIPTION
On our system, in xi-cam, we find that every time the list of objects in the current query is iterated, it is locking the UI because it's a) where the actual mongo query is being conducted and b) on the MainThread. This lock takes up to 0.7 seconds for only one catalog returned, so our UI is locking frequently. I think it's assumed that the self._results_catalog.reload() call takes the time, but with logging on our system, I narrowed it down to the iteration on self._results_catalog.items().

The solution proposed here is to take the iteration out of show_results(), which is on the MainThread, and move into reload(), which is in the ReloadThread, and communicating over new self._new_entries queue. This seems to work well in our environment when the catalog is coming out of mongo. I'm a little concerned because I don't know the world of intake plugins, or when the actually do their work. 